### PR TITLE
Better test for old kanso version.

### DIFF
--- a/build/compile.js
+++ b/build/compile.js
@@ -3,13 +3,17 @@ var couchr = require('couchr');
 module.exports = {
     after: "modules/cleanup",
     run : function(root, path, settings, doc, callback) {
-        var ddoc_url = settings._url + '/_design/' + settings.name;
-        // for older kanso versions
-        if (!ddoc_url) callback(null, doc);
-        get_doc(ddoc_url, settings, function(err, ddoc) {
-            if (ddoc.app_settings) doc.app_settings = ddoc.app_settings;
+        if (settings._url) {
+            var ddoc_url = settings._url + '/_design/' + settings.name;
+            // for older kanso versions
+            get_doc(ddoc_url, settings, function(err, ddoc) {
+                if (err) return callback(err);
+                if (ddoc.app_settings) doc.app_settings = ddoc.app_settings;
+                callback(null, doc);
+            });
+        } else {
             callback(null, doc);
-        });
+        }
     }
 }
 


### PR DESCRIPTION
`ddoc_url` will always be truthy regardless of kanso version. However `settings._url` will be falsey in old
versions.
